### PR TITLE
Fix values parsing for GET request and list data type

### DIFF
--- a/flask_request_validator/validator.py
+++ b/flask_request_validator/validator.py
@@ -179,7 +179,7 @@ def __get_request_value(value_type, name):
     if value_type == FORM:
         return request.form.get(name)
     elif value_type == GET:
-        return request.args.get(name)
+        return ",".join(request.args.getlist(name))
     elif value_type == PATH:
         return request.view_args.get(name)
     elif value_type == JSON:


### PR DESCRIPTION
Currently, when we are trying to obtain multiple values from
GET request(url example: test.com/docs?doc='t1'&doc='t2')
only the first value will be used.