### PR TITLE
Removing pypandoc because it violates the paradigm of build isolation…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ Flask-RESTful==0.3.6
 nose_parameterized==0.5.0
 nose==1.3.7
 coveralls==1.2.0
-pypandoc==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
+import io
 from setuptools import setup
-import pypandoc
 from os import path
 
 current_path = path.abspath(path.dirname(__file__))
 
-long_description = pypandoc.convert('README.md', 'rst')
+with io.open("README.rst", "rt", encoding="utf8") as f:
+    long_description = f.read()
 
 setup(
     name='flask_request_validator',


### PR DESCRIPTION
Repairs v.2.1.1 #40 

Will need to be sent back to PyPi.