### PR TITLE
Small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,17 @@ $ pip install flask_request_validator
 
 `MinLength(6)` - value checks at min length. Works for `str` and `list` values.
 
+`Max(6)` - checks that value is less or equal. Works for `int` and `float`.
+
+`Min(6)` - checks that value is greater or equal. Works for `int` and `float`.
+
 `Enum('value1', 'value2')` - describes allowed values
 
 `NotEmpty` - checks that value is not empty. Works for `str` values and removes leading/trailing whitespace automatically.
+
+`IsDatetimeIsoFormat` - checks that value is a `datetime` in ISO format and converts it to `datetime`.
+
+`IsEmail` - checks that value is a valid email address.
 
 `AbstractRule` - provide possibility to write custom rule
 

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Param description:
 
 ```
 Param(
-    param_name_in_request, # str
-    request_param_type, # where stored param(GET, FORM, JSON, PATH, HEADER)
-    type_of_value, # str, bool, int, float, dict, list - which type we want to have
-    required_or_no, bool - True by default
-    default_value, None by default. You can use lambda for this arg - default=lambda: ['test']
-    list_of_rules
+    name: the name of the request parameter
+    param_type: where stored param(GET, FORM, JSON, PATH, HEADER)
+    value_type: str, bool, int, float, dict, list - which type we want to have
+    required: a bool that indicates wheter a value is required, True by default
+    default: the default value, None by default. You can use lambda for this arg - default=lambda: ['test']
+    rule: the list of rules (see class Rule)
 )
 
 ```

--- a/flask_request_validator/__init__.py
+++ b/flask_request_validator/__init__.py
@@ -1,9 +1,10 @@
 from .validator import validate_params, Param, GET, FORM, PATH, JSON, HEADER
 from .rules import (
-    Pattern,
+    AbstractRule,
+    CompositeRule,
     Enum,
+    NotEmpty,
     MaxLength,
     MinLength,
-    CompositeRule,
-    AbstractRule
+    Pattern,
 )

--- a/flask_request_validator/__init__.py
+++ b/flask_request_validator/__init__.py
@@ -1,4 +1,4 @@
-from .validator import validate_params, Param, GET, FORM, PATH, JSON
+from .validator import validate_params, Param, GET, FORM, PATH, JSON, HEADER
 from .rules import (
     Pattern,
     Enum,

--- a/flask_request_validator/__init__.py
+++ b/flask_request_validator/__init__.py
@@ -3,8 +3,12 @@ from .rules import (
     AbstractRule,
     CompositeRule,
     Enum,
-    NotEmpty,
+    IsDatetimeIsoFormat,
+    IsEmail,
     MaxLength,
     MinLength,
+    Max,
+    Min,
+    NotEmpty,
     Pattern,
 )

--- a/flask_request_validator/date_time_iso_format.py
+++ b/flask_request_validator/date_time_iso_format.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+
+def datetime_from_iso_format(value: str) -> datetime:
+    """
+        for python versions < 3.7 get datetime from isoformat
+        Source: https://github.com/fitoprincipe/ipygee/blob/master/ipygee/tasks.py#L80
+    """
+    d, t = value.split('T')
+    year, month, day = d.split('-')
+    hours, minutes, seconds = t.split(':')
+    seconds = float(seconds[0:-1])
+    sec = int(seconds)
+    microseconds = int((seconds-sec)*1e6)
+
+    return datetime(int(year), int(month), int(day), int(hours), int(minutes), sec, microseconds)

--- a/flask_request_validator/decorators.py
+++ b/flask_request_validator/decorators.py
@@ -1,0 +1,10 @@
+from typing import Any, Callable
+
+
+def overrides(base_class: Any) -> Callable[..., Any]:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        if func.__name__ not in dir(base_class):
+            raise AssertionError(f'Base class "{base_class.__name__}" does not have such a method "{func.__name__}".')
+
+        return func
+    return decorator

--- a/flask_request_validator/exceptions.py
+++ b/flask_request_validator/exceptions.py
@@ -45,7 +45,7 @@ class InvalidHeader(Exception):
         return 'Invalid request header. ' + json.dumps(self.errors)
 
 
-class TooMuchArguments(Exception):
+class TooManyArguments(Exception):
     """
     Got more arguments in request then expected
     """

--- a/flask_request_validator/exceptions.py
+++ b/flask_request_validator/exceptions.py
@@ -52,3 +52,7 @@ class TooManyArguments(Exception):
 
     def __init__(self, msg):
         self.message = msg
+
+
+TooMuchArguments = TooManyArguments
+"""backward compatibility for version 3.0.0"""

--- a/flask_request_validator/rules.py
+++ b/flask_request_validator/rules.py
@@ -25,7 +25,7 @@ class AbstractRule(ABC):
         pass
 
 
-class CompositeRule:
+class CompositeRule(AbstractRule):
 
     def __init__(self, *rules: AbstractRule) -> None:
         self._rules = rules
@@ -33,6 +33,15 @@ class CompositeRule:
     def __iter__(self):
         for rule in self._rules:
             yield rule
+
+    @overrides(AbstractRule)
+    def validate(self, value: Any) -> Tuple[Any, List[str]]:
+        errors = []
+
+        for rule in self._rules:
+            errors.extend(rule.validate(value=value)[1])
+
+        return value, errors
 
 
 class Pattern(AbstractRule):

--- a/flask_request_validator/rules.py
+++ b/flask_request_validator/rules.py
@@ -94,4 +94,5 @@ class NotEmpty(AbstractRule):
 
         if value == '':
             errors.append('Got empty String')
+
         return value, errors

--- a/flask_request_validator/rules.py
+++ b/flask_request_validator/rules.py
@@ -1,8 +1,10 @@
 import re
+import sys
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Tuple, List, Any, Union, Iterable
 
+from .date_time_iso_format import datetime_from_iso_format
 from .decorators import overrides
 
 ALLOWED_TYPES = (str, bool, int, float, dict, list)
@@ -176,8 +178,11 @@ class IsDatetimeIsoFormat(AbstractRule):
         errors = []
 
         try:
-            value = datetime.fromisoformat(value)
-        except (TypeError, ValueError):
+            if sys.version_info >= (3, 7):
+                value = datetime.fromisoformat(value)
+            else:
+                value = datetime_from_iso_format(value)
+        except (TypeError, ValueError, AttributeError):
             errors.append(f'invalid value: {value} is not a datetime in ISO format')
 
         return value, errors

--- a/flask_request_validator/rules.py
+++ b/flask_request_validator/rules.py
@@ -1,98 +1,186 @@
 import re
-from typing import Tuple, List
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Tuple, List, Any, Union, Iterable
+
+from .decorators import overrides
 
 ALLOWED_TYPES = (str, bool, int, float, dict, list)
+REGEX_EMAIL = r"[^@\s]+@[^@\s]+\.[a-zA-Z0-9]+$"
 
 
-class AbstractRule(object):
+class AbstractRule(ABC):
 
-    def validate(self, value):
+    @abstractmethod
+    def validate(self, value: Any) -> Tuple[Any, List[str]]:
         """
-        :param mixed value:
-        :rtype: list|None
-        :return: tuple of value and errors
-        :rtype: list
+            Validate value and return a tuple of value and a list of errors.
+            The error list should be empty iff value is valid.
+            The returned value does not have to match the input value. Feel free to implement conversion logic.
+
+            :param Any value:
+            :return: tuple of value and errors
+            :rtype: (Any, list of str)
         """
-        raise NotImplementedError()
+        pass
 
 
-class CompositeRule(object):
+class CompositeRule:
 
-    def __init__(self, *rules):
-        self.rules = rules
+    def __init__(self, *rules: AbstractRule) -> None:
+        self._rules = rules
 
     def __iter__(self):
-        for rule in self.rules:
+        for rule in self._rules:
             yield rule
 
 
 class Pattern(AbstractRule):
 
-    def __init__(self, pattern):
-        """
-        :param str pattern:
-        """
-        self.pattern = re.compile(pattern)
+    def __init__(self, pattern: str) -> None:
+        self._pattern = re.compile(pattern)
 
-    def validate(self, value):
+    @overrides(AbstractRule)
+    def validate(self, value: str) -> Tuple[str, List[str]]:
         errors = []
-        if not self.pattern.search(value):
-            errors.append('Value "%s" does not match pattern %s' %
-                          (value, self.pattern.pattern))
+
+        if not self._pattern.search(string=str(value)):
+            errors.append(f'Value "{value}" does not match pattern {self._pattern.pattern}')
+
         return value, errors
 
 
 class Enum(AbstractRule):
 
-    def __init__(self, *allowed_values):
-        self.allowed_values = allowed_values
+    def __init__(self, *allowed_values: List[Any]) -> None:
+        self._allowed_values = allowed_values
 
-    def validate(self, value):
+    @overrides(AbstractRule)
+    def validate(self, value: Any) -> Tuple[Any, List[str]]:
         errors = []
-        if value not in self.allowed_values:
-            errors.append('Incorrect value "%s". Allowed values: %s' %
-                          (value, self.allowed_values))
+
+        if value not in self._allowed_values:
+            errors.append(f'Incorrect value "{value}". Allowed values: {self._allowed_values}')
+
         return value, errors
 
 
 class MaxLength(AbstractRule):
 
-    def __init__(self, length):
-        """
-        :param int length:
-        """
-        self.length = length
+    def __init__(self, length: int) -> None:
+        self._length = length
 
-    def validate(self, value):
+    @overrides(AbstractRule)
+    def validate(self, value: Union[Iterable, str]) -> Tuple[Union[str, Iterable], List[str]]:
         errors = []
-        if len(value) > self.length:
-            errors.append('Invalid length for value "%s". Max length = %s' %
-                          (value, self.length))
+
+        if len(value) > self._length:
+            errors.append(f'Invalid length for value "{value}". Max length = {self._length}')
+
         return value, errors
 
 
 class MinLength(AbstractRule):
 
-    def __init__(self, length):
-        """
-        :param int length:
-        """
-        self.length = length
+    @overrides(AbstractRule)
+    def __init__(self, length: int) -> None:
+        self._length = length
 
-    def validate(self, value):
+    def validate(self, value: Union[Iterable, str]) -> Tuple[Union[str, Iterable], List[str]]:
         errors = []
-        if len(value) < self.length:
-            errors.append('Invalid length for value "%s". Min length = %s'
-                          % (value, self.length))
+
+        if len(value) < self._length:
+            errors.append(f'Invalid length for value "{value}". Min length = {self._length}')
+
         return value, errors
 
 
 class NotEmpty(AbstractRule):
+
+    @overrides(AbstractRule)
     def validate(self, value: str) -> Tuple[str, List[str]]:
         errors = []
         value = value.strip()
 
         if value == '':
-            errors.append('Got empty String')
+            errors.append('Got empty String which is invalid')
+
+        return value, errors
+
+
+class Max(AbstractRule):
+
+    def __init__(self, value: Union[int, float], include_boundary: bool = True) -> None:
+        """
+            >>> Max(7, True).validate(7)
+            True
+            >>> Max(7, False).validate(7)
+            False
+            >>> Max(7, False).validate(6.999)
+            True
+        """
+        self._value = value
+        self._include_boundary = include_boundary
+
+    @overrides(AbstractRule)
+    def validate(self, value: Union[int, float]) -> Tuple[Union[int, float], List[str]]:
+        errors = []
+
+        if value > self._value and self._include_boundary:
+            errors.append(f'greater then allowed: {value} is not <= {self._value}')
+        elif value >= self._value and not self._include_boundary:
+            errors.append(f'greater then allowed: {value} is not < {self._value}')
+
+        return value, errors
+
+
+class Min(AbstractRule):
+
+    def __init__(self, value: Union[int, float], include_boundary: bool = True) -> None:
+        """
+            >>> Min(7, True).validate(7)
+            True
+            >>> Min(7, False).validate(7)
+            False
+            >>> Min(7, False).validate(7.001)
+            True
+        """
+        self._value = value
+        self._include_boundary = include_boundary
+
+    @overrides(AbstractRule)
+    def validate(self, value: Union[int, float]) -> Tuple[Union[int, float], List[str]]:
+        errors = []
+
+        if value < self._value and self._include_boundary:
+            errors.append(f'smaller then allowed: {value} is not >= {self._value}')
+        elif value <= self._value and not self._include_boundary:
+            errors.append(f'smaller then allowed: {value} is not > {self._value}')
+
+        return value, errors
+
+
+class IsDatetimeIsoFormat(AbstractRule):
+
+    @overrides(AbstractRule)
+    def validate(self, value: str) -> Tuple[Union[str, datetime], List[str]]:
+        errors = []
+
+        try:
+            value = datetime.fromisoformat(value)
+        except (TypeError, ValueError):
+            errors.append(f'invalid value: {value} is not a datetime in ISO format')
+
+        return value, errors
+
+
+class IsEmail(AbstractRule):
+
+    @overrides(AbstractRule)
+    def validate(self, value: str) -> Tuple[str, List[str]]:
+        errors = []
+
+        if not re.fullmatch(pattern=REGEX_EMAIL, string=value):
+            errors.append(f'invalid email address: {value}')
 
         return value, errors

--- a/flask_request_validator/validator.py
+++ b/flask_request_validator/validator.py
@@ -1,6 +1,7 @@
 import types
 import inspect
 from functools import wraps
+from typing import Tuple
 
 from flask import request
 
@@ -122,7 +123,7 @@ def validate_params(*params: Param, return_as_kwargs: bool = True):
     return validate_request
 
 
-def __get_errors(params):
+def __get_errors(params: Tuple[Param, ...]):
     """
     Returns errors of validation and valid values
     :param tuple params: (Param(), Param(), ...)

--- a/flask_request_validator/validator.py
+++ b/flask_request_validator/validator.py
@@ -216,7 +216,7 @@ def __get_request_value(value_type, name):
         return request.view_args.get(name)
     elif value_type == JSON:
         json_ = request.get_json()
-        return json_.get(name) if json_ else json_
+        return json_.get(name) if json_ else None
     elif value_type == HEADER:
         return request.headers.get(name)  # None is fine here
     else:

--- a/flask_request_validator/validator.py
+++ b/flask_request_validator/validator.py
@@ -76,7 +76,7 @@ class Param(object):
         return value
 
 
-def validate_params(*params):
+def validate_params(*params: Param, return_as_kwargs: bool = True):
     """
     Validate route of request. Example:
 
@@ -109,10 +109,13 @@ def validate_params(*params):
 
             spec = inspect.getfullargspec(func)
 
-            if spec.varkw == 'kwargs':
-                return func(**{v.name: endpoint_args[i] for i, v in enumerate(params) if endpoint_args[i] is not None})
+            kwargs = {k: v for k, v in kwargs.items() if k not in [x.name for x in params]}
 
-            return func(*endpoint_args)
+            if spec.varkw == 'kwargs' and return_as_kwargs:
+                endpoint_kw = {v.name: endpoint_args[i] for i, v in enumerate(params) if endpoint_args[i] is not None}
+                return func(**{**kwargs, **endpoint_kw})
+
+            return func(*endpoint_args, **kwargs)
 
         return wrapper
 

--- a/flask_request_validator/validator.py
+++ b/flask_request_validator/validator.py
@@ -8,7 +8,7 @@ from .exceptions import (
     NotAllowedType,
     UndefinedParamType,
     InvalidRequest,
-    TooMuchArguments,
+    TooManyArguments,
     InvalidHeader
 )
 from .rules import CompositeRule, ALLOWED_TYPES
@@ -102,7 +102,7 @@ def validate_params(*params):
                     raise InvalidRequest(errors)
 
             if __all_params_are_of_type(params, JSON):
-                __check_if_too_much_params_in_request(params)
+                __check_if_too_many_params_in_request(params)
 
             if args:
                 endpoint_args = (args[0], ) + tuple(endpoint_args)
@@ -188,13 +188,13 @@ def __all_params_are_of_type(params, param_type: str) -> bool:
     return True
 
 
-def __check_if_too_much_params_in_request(params):
+def __check_if_too_many_params_in_request(params):
     expected = {param.name for param in params}
     actual = request.get_json().keys()
     unexpected_keys = {key for key in actual if key not in expected}
 
     if unexpected_keys:
-        raise TooMuchArguments(f'Got unexpected keys: {unexpected_keys}')
+        raise TooManyArguments(f'Got unexpected keys: {unexpected_keys}')
 
 
 def __get_request_value(value_type, name):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,6 +1,7 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 
+from flask_request_validator.date_time_iso_format import datetime_from_iso_format
 from flask_request_validator.rules import IsEmail, IsDatetimeIsoFormat, NotEmpty, Max, Min, AbstractRule, MinLength, \
     MaxLength, Enum, Pattern, CompositeRule
 
@@ -110,11 +111,20 @@ class TestRules(unittest.TestCase):
         rule = IsDatetimeIsoFormat()
         now = datetime.now()
 
-        self.assertEqual((now, []), rule.validate(now.isoformat()))
-        self.assertEqual((datetime.combine(now, datetime.min.time()), []), rule.validate(now.date().isoformat()))
+        actual, errors = rule.validate(now.isoformat())
+        self.assertTrue(abs(now - actual) < timedelta(milliseconds=1))
+        self.assertEqual([], errors)
 
         for value in ['invalid', 42, '12.12.2020']:
             self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_datetime_iso_format_python_3_6(self) -> None:
+        now = datetime.now()
+        self.assertTrue(abs(now - datetime_from_iso_format(now.isoformat())) < timedelta(milliseconds=1))
+
+        for value in ['invalid', 42, '12.12.2020']:
+            with self.assertRaises(expected_exception=(AttributeError, ValueError)):
+                datetime_from_iso_format(value=value)
 
     def test_is_email_rule(self) -> None:
         rule = IsEmail()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,120 @@
+import unittest
+from datetime import datetime
+
+from flask_request_validator.rules import IsEmail, IsDatetimeIsoFormat, NotEmpty, Max, Min, AbstractRule, MinLength, \
+    MaxLength, Enum, Pattern, CompositeRule
+
+
+class TestRules(unittest.TestCase):
+
+    def test_abstract_rule(self) -> None:
+        with self.assertRaises(expected_exception=TypeError):
+            AbstractRule()
+
+    def test_composite_rule(self) -> None:
+        rules = [Min(1), Max(2)]
+        rule = CompositeRule(*rules)
+
+        for value in rule:
+            self.assertIn(value, rules)
+
+    def test_pattern_rule(self) -> None:
+        rule = Pattern(r'^[0-9]*$')
+
+        for value in ['0', '23456', 213, '1100']:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in ['hello', ' ', '2345h456z']:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_enum_rule(self) -> None:
+        values = ['Hi', 'there!', 42, None, unittest.TestCase]
+        rule = Enum(*values)
+
+        for value in values:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in ['hello', list(range(42)), 4 * ' ']:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_max_length_rule(self) -> None:
+        rule = MaxLength(3)
+
+        for value in ['hi!', 3 * ' ', [1, 2, 3], '', 'hi', 2 * ' ', [1, 2], []]:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in ['hello', list(range(42)), 4 * ' ']:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_min_length_rule(self) -> None:
+        rule = MinLength(3)
+
+        for value in ['hi!', 'hello', 3 * ' ', [1, 2, 3], list(range(42))]:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in ['', 'hi', 2 * ' ', [1, 2], []]:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_not_empty_rule(self) -> None:
+        rule = NotEmpty()
+
+        for value in ['hi', '  v a  l   i d   ']:
+            self.assertEqual((value.strip(), []), rule.validate(value))
+
+        for value in ['', '   ', '         ']:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_max_rule_include_boundary_true(self) -> None:
+        rule = Max(3, include_boundary=True)
+
+        for value in [-42, -2, -1, 0, 1, 2, 3]:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in [4, 5, 6, 100]:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_max_rule_include_boundary_false(self) -> None:
+        rule = Max(3, include_boundary=False)
+
+        for value in [-42, -2, -1, 0, 1, 2, 2.999]:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in [3, 4, 5, 6, 100]:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_min_rule_include_boundary_true(self) -> None:
+        rule = Min(4, include_boundary=True)
+
+        for value in [4, 5, 6, 100]:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in [-42, -2, -1, 0, 1, 2, 3]:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_min_rule_include_boundary_false(self) -> None:
+        rule = Min(4, include_boundary=False)
+
+        for value in [4.001, 5, 6, 100]:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in [-42, -2, -1, 0, 1, 2, 3, 4]:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_datetime_iso_format_rule(self) -> None:
+        rule = IsDatetimeIsoFormat()
+        now = datetime.now()
+
+        self.assertEqual((now, []), rule.validate(now.isoformat()))
+        self.assertEqual((datetime.combine(now, datetime.min.time()), []), rule.validate(now.date().isoformat()))
+
+        for value in ['invalid', 42, '12.12.2020']:
+            self.assertEqual(1, len(rule.validate(value)[1]))
+
+    def test_is_email_rule(self) -> None:
+        rule = IsEmail()
+
+        for value in ['fred@web.de', 'genial@gmail.com', 'test@test.co.uk']:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in ['fred', 'fred@web', 'fred@w@eb.de', 'fred@@web.de', 'invalid@invalid']:
+            self.assertEqual(1, len(rule.validate(value)[1]))

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -15,8 +15,14 @@ class TestRules(unittest.TestCase):
         rules = [Min(1), Max(2)]
         rule = CompositeRule(*rules)
 
-        for value in rule:
-            self.assertIn(value, rules)
+        for r in rule:
+            self.assertIn(r, rules)
+
+        for value in [1.0, 1, 1.0002, 1.2, 1.5, 1.9999, 2, 2.0]:
+            self.assertEqual((value, []), rule.validate(value))
+
+        for value in [-42, -1, 0, 0.999, 2.00001, 2.4, 3.8, 46868841635]:
+            self.assertEqual(1, len(rule.validate(value)[1]))
 
     def test_pattern_rule(self) -> None:
         rule = Pattern(r'^[0-9]*$')

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -146,8 +146,8 @@ def kwargs_are_okay(**kwargs):
     Param('city', JSON, str, rules=[Enum('Minsk')]),
     return_as_kwargs=False,
 )
-def kwargs_are_not_okay(a, b, c, d):
-    return flask.jsonify({'a': a, 'b': b, 'c': c, 'd': d})
+def kwargs_are_not_okay(a, b, c, d, **kwargs):
+    return flask.jsonify({'a': a, 'b': b, 'c': c, 'd': d, **kwargs})
 
 
 @app.route('/header', methods=['GET'])

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -15,7 +15,7 @@ from flask_request_validator import (
     Pattern,
     validate_params
 )
-from flask_request_validator.exceptions import InvalidRequest, TooMuchArguments, InvalidHeader
+from flask_request_validator.exceptions import InvalidRequest, TooManyArguments, InvalidHeader
 from flask_request_validator.rules import MaxLength, MinLength, NotEmpty
 from flask_request_validator.validator import PATH, FORM, JSON, HEADER
 
@@ -262,7 +262,7 @@ class TestValidator(TestCase):
             with self.assertRaises(expected_exception=InvalidRequest):
                 client.get('/kwargs', data=json.dumps(data), content_type='application/json')
 
-    def test_too_much_arguments(self):
+    def test_too_many_arguments(self):
         with app.test_client() as client:
             data = {
                 'first_name': 'Egon',
@@ -271,7 +271,7 @@ class TestValidator(TestCase):
                 'city': 'Minsk',
                 'an_unhandled_arg': 'this is too much! I will raise an TooMuchArgument exception!'
             }
-            with self.assertRaises(expected_exception=TooMuchArguments):
+            with self.assertRaises(expected_exception=TooManyArguments):
                 client.get('/kwargs', data=json.dumps(data), content_type='application/json')
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -168,6 +168,14 @@ def take_kwargs_that_validator_shall_ignore(value: str, num: int, verbose: bool)
     return flask.jsonify({'value': value, 'num': num, 'verbose': verbose})
 
 
+@app.route('/issue46', methods=['GET'])
+@validate_params(
+    Param('my_string', JSON, str, required=False, default='my_default'),
+)
+def issue_46(s: str):
+    return flask.jsonify({'my_string': s})
+
+
 class TestValidator(TestCase):
 
     def test_invalid_route(self):
@@ -320,6 +328,12 @@ class TestValidator(TestCase):
             }
             with self.assertRaises(expected_exception=TooManyArguments):
                 client.get('/kwargs', data=json.dumps(data), content_type='application/json')
+
+    def test_default_string(self):
+        with app.test_client() as client:
+            res = client.get('/issue46', data=json.dumps({}), content_type='application/json')
+            self.assertEqual(200, res.status_code)
+            self.assertEqual('my_default', res.json['my_string'])
 
 
 class TestParam(TestCase):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -15,7 +15,7 @@ from flask_request_validator import (
     Pattern,
     validate_params
 )
-from flask_request_validator.exceptions import InvalidRequest, TooManyArguments, InvalidHeader
+from flask_request_validator.exceptions import InvalidRequest, TooManyArguments, InvalidHeader, TooMuchArguments
 from flask_request_validator.rules import MaxLength, MinLength, NotEmpty
 from flask_request_validator.validator import PATH, FORM, JSON, HEADER
 
@@ -328,6 +328,10 @@ class TestValidator(TestCase):
                 'an_unhandled_arg': 'this is too much! I will raise an TooMuchArgument exception!'
             }
             with self.assertRaises(expected_exception=TooManyArguments):
+                client.get('/kwargs', data=json.dumps(data), content_type='application/json')
+
+            # test backward compatibility
+            with self.assertRaises(expected_exception=TooMuchArguments):
                 client.get('/kwargs', data=json.dumps(data), content_type='application/json')
 
     def test_default_string(self):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -60,6 +60,7 @@ class TestApi(Resource):
             mimetype='application/json'
         )
 
+
 type_composite = CompositeRule(Enum('type1', 'type2'))
 
 


### PR DESCRIPTION
Hi there! I found out that my last changes created some problems with `kwargs`. So I decided to implement a new parameter called `return_as_kwargs` to control how `validate_params()` will return the values.

Example:
```python 
@app.route('/no_kwargs', methods=['GET'])
@validate_params(
    Param('first_name', JSON, str, rules=[MaxLength(4)]),
    Param('last_name', JSON, str, rules=[MinLength(4)]),
    Param('street', JSON, str, rules=[NotEmpty()]),
    Param('city', JSON, str, rules=[Enum('Minsk')]),
    return_as_kwargs=False,
)
def kwargs_are_not_okay(a, b, c, d, **kwargs):
   pass
```

This merge request contains:
- Implementation of new parameter `return_as_kwargs` like mentioned above.
- Support for "incoming" `**kwargs` of some kind of higher-level-decorator. This should fix https://github.com/d-ganchar/flask_request_validator/issues/47 
- Fixes https://github.com/d-ganchar/flask_request_validator/issues/46
- Fixes https://github.com/d-ganchar/flask_request_validator/issues/44
- Tests

And this time my changes are not breaking changes ;)

Best,
Willi