### PR TITLE
fixes bug conflict of identical parameter names

### DIFF
--- a/flask_request_validator/exceptions.py
+++ b/flask_request_validator/exceptions.py
@@ -1,19 +1,25 @@
 import json
 
 
-class UndefinedParamType(Exception):
+class RequestError(Exception):
+    """
+    Base flask_request_validator exception
+    """
+
+
+class UndefinedParamType(RequestError):
     """
     Not allowed type of param(GET, POST )
     """
 
 
-class NotAllowedType(Exception):
+class NotAllowedType(RequestError):
     """
     Not allowed type. See: rules.ALLOWED_TYPES
     """
 
 
-class InvalidRequest(Exception):
+class InvalidRequest(RequestError):
     """
     GET or POST data is invalid
     """
@@ -29,7 +35,7 @@ class InvalidRequest(Exception):
         return 'Invalid request data. ' + json.dumps(self.errors)
 
 
-class InvalidHeader(Exception):
+class InvalidHeader(RequestError):
     """
     request header data is invalid
     """
@@ -45,7 +51,18 @@ class InvalidHeader(Exception):
         return 'Invalid request header. ' + json.dumps(self.errors)
 
 
-class TooManyArguments(Exception):
+class ParameterNameIsNotUnique(RequestError):
+    """
+    Got same parameter name more than once. Example:
+
+    @validate_params(
+        Param('user', PATH, str),
+        Param('user', JSON, str),
+    )
+    """
+
+
+class TooManyArguments(RequestError):
     """
     Got more arguments in request then expected
     """

--- a/flask_request_validator/validator.py
+++ b/flask_request_validator/validator.py
@@ -10,7 +10,7 @@ from .exceptions import (
     UndefinedParamType,
     InvalidRequest,
     TooManyArguments,
-    InvalidHeader
+    InvalidHeader, ParameterNameIsNotUnique
 )
 from .rules import CompositeRule, ALLOWED_TYPES
 
@@ -113,6 +113,7 @@ def validate_params(*params: Param, return_as_kwargs: bool = True):
             kwargs = {k: v for k, v in kwargs.items() if k not in [x.name for x in params]}
 
             if spec.varkw == 'kwargs' and return_as_kwargs:
+                __check_that_param_names_are_unique(params)
                 endpoint_kw = {v.name: endpoint_args[i] for i, v in enumerate(params) if endpoint_args[i] is not None}
                 return func(**{**kwargs, **endpoint_kw})
 
@@ -199,6 +200,12 @@ def __check_if_too_many_params_in_request(params):
 
     if unexpected_keys:
         raise TooManyArguments(f'Got unexpected keys: {unexpected_keys}')
+
+
+def __check_that_param_names_are_unique(params):
+    names = [param.name for param in params]
+    if len(names) != len(set(names)):
+        raise ParameterNameIsNotUnique()
 
 
 def __get_request_value(value_type, name):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with io.open('README.rst', 'rt', encoding='utf8') as f:
 
 setup(
     name='flask_request_validator',
-    version='3.0.1',
+    version='3.0.2',
     description='Flask request data validation',
     long_description=long_description,
     url='https://github.com/d-ganchar/flask_request_validator',


### PR DESCRIPTION
fixes https://github.com/d-ganchar/flask_request_validator/issues/55

I raise an exception in case of using `**kwargs` and identical names.