### PR TITLE
Open REGEX_EMAIL for usage

### DIFF
--- a/flask_request_validator/__init__.py
+++ b/flask_request_validator/__init__.py
@@ -24,4 +24,5 @@ from .rules import (
     Pattern,
     Datetime,
     Number,
+    REGEX_EMAIL,
 )


### PR DESCRIPTION
I'm working on a project where I also use Cerberus' Validator

We use the `isEmail` from `flask_request_validator` but to work cleaner, we would also need to pass the `REGEX_EMAIL` to Cerberus, having then one trusted source for email validation.

For the moment I just copy-pasted the regex to use it directly. I'll keep it that way if you don't want to open `REGEX_EMAIL` :smile: 